### PR TITLE
Add steam bbcode writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are currently three 2bbcode writers in this project, addressing different 
 -   `bbcode_hubzilla.lua` – a fork of `2bbcode_phpbb.lua` by
     [@slobinger](https://github.com/slobinger/2bbcode), targeting the BBCode
     used by [**Hubzilla**](https://hub.netzgemeinde.eu/help/en/member/bbcode).
-- `bbcode_steam.lua` – writer for steam flavour bbcode by @0x00002a[https://github.com/0x00002a/2bbcode]
+- `bbcode_steam.lua` – writer for steam flavour bbcode by [@0x00002a](https://github.com/0x00002a/2bbcode)
 
 About Pandoc
 ------------

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ Introduction
 
 Since pandoc ships with a built-in Lua interpreter, using **2bbcode** wrtiers doesn’t require installing Lua on the system.
 
-There are currently two 2bbcode writers in this project, addressing different BBCode flavors:
+There are currently three 2bbcode writers in this project, addressing different BBCode flavors:
 
 -   `2bbcode.lua` – the original 2bbcode writer by [@lilydjwg](https://github.com/lilydjwg/2bbcode), targeting the BBCode used by [FluxBB](https://fluxbb.org/forums/help.php#bbcode).
 -   `bbcode_phpbb.lua` – a fork of `2bbcode.lua` by [@tajmone](https://github.com/tajmone/2bbcode), targeting the BBCode used by [**phpBB**](https://www.phpbb.com/community/faq.php?mode=bbcode).
 -   `bbcode_hubzilla.lua` – a fork of `2bbcode_phpbb.lua` by
     [@slobinger](https://github.com/slobinger/2bbcode), targeting the BBCode
     used by [**Hubzilla**](https://hub.netzgemeinde.eu/help/en/member/bbcode).
+- `bbcode_steam.lua` – writer for steam flavour bbcode by @0x00002a[https://github.com/0x00002a/2bbcode]
 
 About Pandoc
 ------------

--- a/bbcode_steam.lua
+++ b/bbcode_steam.lua
@@ -70,7 +70,7 @@ function Image(s, src, tit)
 end
 
 function Code(s, attr)
-  return "[b]" .. s .. "[/b]"
+  return "[code]" .. s .. "[/code]"
 end
 
 function InlineMath(s)
@@ -127,7 +127,7 @@ function OrderedList(items)
   for _, item in ipairs(items) do
     table.insert(buffer, "[*]" .. item)
   end
-  return "[list=1]\n" .. table.concat(buffer, "\n") .. "\n[/list]"
+  return "[olist]\n" .. table.concat(buffer, "\n") .. "\n[/olist]"
 end
 
 -- Revisit association list STackValue instance.
@@ -168,7 +168,7 @@ function Table(caption, aligns, widths, headers, rows)
 end
 
 function RawBlock(format, str)
-  return '[code]\n' .. str .. '\n[/code]\n'
+  return '[noparse]\n' .. str .. '\n[/noparse]\n'
 end
 
 function Span(s, attr)

--- a/bbcode_steam.lua
+++ b/bbcode_steam.lua
@@ -1,0 +1,191 @@
+-- Invoke with: pandoc -t sample.lua
+
+-- Blocksep is used to separate block elements.
+function Blocksep()
+  return "\n\n"
+end
+
+-- This function is called once for the whole document. Parameters:
+-- body, title, date are strings; authors is an array of strings;
+-- variables is a table.  One could use some kind of templating
+-- system here; this just gives you a simple standalone HTML file.
+function Doc(body, title, authors, date, variables)
+  return body .. '\n'
+end
+
+-- The functions that follow render corresponding pandoc elements.
+-- s is always a string, attr is always a table of attributes, and
+-- items is always an array of strings (the items in a list).
+-- Comments indicate the types of other variables.
+
+function Str(s)
+  return s
+end
+
+function Space()
+  return " "
+end
+
+function LineBreak()
+  return "\n"
+end
+
+function Emph(s)
+  return "[i]" .. s .. "[/i]"
+end
+
+function Strong(s)
+  return "[b]" .. s .. "[/b]"
+end
+
+function Subscript(s)
+  error("Subscript isn't supported")
+end
+
+function Superscript(s)
+  return s
+end
+
+function SmallCaps(s)
+  error("SmallCaps isn't supported")
+end
+
+function Strikeout(s)
+  return '[strike]' .. s .. '[/strike]'
+end
+
+function Link(s, src, tit)
+  local ret = '[url'
+  if s then
+    ret = ret .. '=' .. src
+  else
+    s = src
+  end
+  ret = ret .. "]" .. s .. "[/url]"
+  return ret
+end
+
+function Image(s, src, tit)
+  return "[img=" .. tit .. "]" .. src .. "[/img]"
+end
+
+function Code(s, attr)
+  return "[b]" .. s .. "[/b]"
+end
+
+function InlineMath(s)
+  error("InlineMath isn't supported")
+end
+
+function DisplayMath(s)
+  error("DisplayMath isn't supported")
+end
+
+function Note(s)
+  error("Note isn't supported")
+end
+
+function Plain(s)
+  return s
+end
+
+function Para(s)
+  return s
+end
+
+-- lev is an integer, the header level.
+function Header(lev, s, attr)
+  return "[h" .. lev .. "]" .. s .. "[/h" .. lev .. "]"
+end
+
+function BlockQuote(s)
+  return "[quote]\n" .. s .. "\n[/quote]"
+end
+
+function HorizontalRule()
+  return "--------------------------------------------------------------------------------"
+end
+
+function SoftBreak()
+  return " "
+end
+
+function CodeBlock(s, attr)
+  return "[code]\n" .. s .. '\n[/code]'
+end
+
+function BulletList(items)
+  local buffer = {}
+  for _, item in ipairs(items) do
+    table.insert(buffer, "[*]" .. item)
+  end
+  return "[list]\n" .. table.concat(buffer, "\n") .. "\n[/list]"
+end
+
+function OrderedList(items)
+  local buffer = {}
+  for _, item in ipairs(items) do
+    table.insert(buffer, "[*]" .. item)
+  end
+  return "[list=1]\n" .. table.concat(buffer, "\n") .. "\n[/list]"
+end
+
+-- Revisit association list STackValue instance.
+function DefinitionList(items)
+  local buffer = {}
+  for _, item in pairs(items) do
+    for k, v in pairs(item) do
+      table.insert(buffer, "[b]" .. k .. "[/b]:\n" ..
+                        table.concat(v, "\n"))
+    end
+  end
+  return table.concat(buffer, "\n")
+end
+
+function DoubleQuoted(item) 
+	return "\"" .. item .. "\"";
+end
+
+-- Convert pandoc alignment to something HTML can use.
+-- align is AlignLeft, AlignRight, AlignCenter, or AlignDefault.
+function html_align(align)
+  if align == 'AlignLeft' then
+    return 'left'
+  elseif align == 'AlignRight' then
+    return 'right'
+  elseif align == 'AlignCenter' then
+    return 'center'
+  else
+    return 'left'
+  end
+end
+
+-- Caption is a string, aligns is an array of strings,
+-- widths is an array of floats, headers is an array of
+-- strings, rows is an array of arrays of strings.
+function Table(caption, aligns, widths, headers, rows)
+  error("Table isn't supported")
+end
+
+function RawBlock(format, str)
+  return '[code]\n' .. str .. '\n[/code]\n'
+end
+
+function Span(s, attr)
+  return s
+end
+
+function Div(s, attr)
+  return s .. '\n'
+end
+
+-- The following code will produce runtime warnings when you haven't defined
+-- all of the functions you need for the custom writer, so it's useful
+-- to include when you're working on a writer.
+local meta = {}
+meta.__index =
+  function(_, key)
+    io.stderr:write(string.format("WARNING: Undefined function '%s'\n",key))
+    return function() return "" end
+  end
+setmetatable(_G, meta)

--- a/bbcode_steam.lua
+++ b/bbcode_steam.lua
@@ -70,7 +70,7 @@ function Image(s, src, tit)
 end
 
 function Code(s, attr)
-  return "[code]" .. s .. "[/code]"
+  return "[i][b]" .. s .. "[/b][/i]"
 end
 
 function InlineMath(s)


### PR DESCRIPTION
This is the bbcode filter I use to convert my markdown READMEs into bbcode for steam descriptions. Just thought I'd upstream it

**Testing**
This filter has been tested for markdown documents but no other formats

**Conversion**
The filter is somewhat opinionated since steam bbcode is quite limited. `inline code/monospace for example` is formatted as ***bold italic***