### PR TITLE
Return email addresses without `[url]` tag in case of mailto links

### DIFF
--- a/bbcode_phpbb.lua
+++ b/bbcode_phpbb.lua
@@ -110,6 +110,9 @@ function Strikeout(s)
 end
 
 function Link(s, src, tit)
+  if src:find('mailto:', 1, true) == 1 then
+    return s
+  fi
   local ret = '[url'
   if s then
     ret = ret .. '=' .. src


### PR DESCRIPTION
phpBB doesn't support mailto links. This fixes broken formatting of email addresses.

See https://www.phpbb.com/community/viewtopic.php?t=2157009

Signed-off-by: Jonas <jonas@freesources.org>